### PR TITLE
Suggestion: Migration from poetry to uv

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,13 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - name: Install uv with cache
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.2"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
       - name: Install nox
         uses: wntrblm/nox@2025.02.09
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 poetry.lock
 dist/
 .idea/
+.venv/
+uv.lock
+ifdo.egg-info/
+build/

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,9 @@
-from nox import session
+import nox
 
-@session(python=["3.10", "3.11", "3.12", "3.13"])
+
+nox.options.default_venv_backend = "uv"
+
+@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests(session):
     session.install("pytest", "jsonschema", ".")
     session.run("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,37 @@
-[tool.poetry]
+[project]
 name = "ifdo"
 version = "1.2.5"
 description = "Python iFDO implementation"
-authors = [
-    "Kevin Barnard <kbarnard@mbari.org>",
-    "Chris Jackett <chris.jackett@csiro.au>",
-]
-license = "MIT"
 readme = "README.md"
+authors = [
+    {name = "Kevin Barnard", email = "kbarnard@mbari.org"},
+    {name = "Chris Jackett", email = "chris.jackett@csiro.au"},
+]
+license = {text = "MIT"}
+requires-python = ">=3.10"
 
-[tool.poetry.dependencies]
-python = "^3.10"
-stringcase = "^1.2.0"
-pyyaml = "^6.0"
-pydantic = "^2.4.2"
+dependencies = [
+    "stringcase<2.0.0,>=1.2.0",
+    "pyyaml<7.0,>=6.0",
+    "pydantic<3.0.0,>=2.4.2",
+]
 
-[tool.poetry.group.dev.dependencies]
-pre-commit = "^4.0.1"
-ruff = "^0.7.3"
-black = "^24.10.0"
-mypy = "^1.13.0"
-bandit = "^1.7.10"
-types-pyyaml = "^6.0.12.20240917"
-pytest = "^8.3.4"
-nox = "^2025.2.9"
-jsonschema = "^4.23.0"
+[dependency-groups]
+dev = [
+    "pre-commit<5.0.0,>=4.0.1",
+    "ruff<1.0.0,>=0.7.3",
+    "black<25.0.0,>=24.10.0",
+    "mypy<2.0.0,>=1.13.0",
+    "bandit<2.0.0,>=1.7.10",
+    "types-pyyaml<7.0.0.0,>=6.0.12.20240917",
+    "pytest<9.0.0,>=8.3.4",
+    "nox<2026.0.0,>=2025.2.9",
+    "jsonschema<5.0.0,>=4.23.0"
+]
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.uv]
+package=true
+
+[tool.setuptools.packages.find]
+include = ["ifdo*"]
+


### PR DESCRIPTION
Just a small suggestion to move from poetry to uv as a project management tool. The big upside being, that nox can utilize uv capability of installing and managing Python versions on a non system level. This means, that for running the full test matrix defined in the nox file, the Python versions do not have to be installed on a system level.

If you want to try uv out for yourself, you can find the documentation here: https://docs.astral.sh/uv