### PR TITLE
Added image-set-local-path field

### DIFF
--- a/ifdo/models.py
+++ b/ifdo/models.py
@@ -676,6 +676,7 @@ class ImageData:
         image_license (ImageLicense | None): License information for the image.
         image_copyright (str | None): Copyright information for the image.
         image_abstract (str | None): Brief description or abstract of the image content.
+        image_set_local_path (str | None: Local relative or absolute path to a directory in which the referenced image files are located.
         image_acquisition (ImageAcquisition | None): Details about the image acquisition process.
         image_quality (ImageQuality | None): Quality metrics for the image.
         image_deployment (ImageDeployment | None): Information about the deployment of the imaging equipment.
@@ -744,6 +745,7 @@ class ImageData:
     image_license: ImageLicense | None = None
     image_copyright: str | None = None
     image_abstract: str | None = None
+    image_set_local_path: str | None = None
 
     # iFDO capture (optional)
     image_acquisition: ImageAcquisition | None = None
@@ -824,6 +826,7 @@ class ImageSetHeader:
         image_license (ImageLicense | None): License information for the image.
         image_copyright (str | None): Copyright information for the image.
         image_abstract (str | None): Brief description or abstract of the image content.
+        image_set_local_path (str | None: Local relative or absolute path to a directory in which the referenced image files are located.
         image_acquisition (ImageAcquisition | None): Details about the image acquisition process.
         image_quality (ImageQuality | None): Quality metrics for the image.
         image_deployment (ImageDeployment | None): Information about the deployment of the imaging equipment.
@@ -896,6 +899,7 @@ class ImageSetHeader:
     image_license: ImageLicense | None = None
     image_copyright: str | None = None
     image_abstract: str | None = None
+    image_set_local_path: str | None = None
 
     # iFDO capture (optional)
     image_acquisition: ImageAcquisition | None = None

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 from nox import session
 
+
 @session(python=["3.10", "3.11", "3.12", "3.13"])
 def tests(session):
     session.install("pytest", "jsonschema", ".")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -12,4 +12,6 @@ def test_load():
     ifdo = iFDO.from_dict(json_data)
 
     assert ifdo.image_set_header.image_set_name == "SO268 SO268-1_21-1_OFOS SO_CAM-1_Photo_OFOS"
-    assert ifdo.image_set_items["SO268-1_21-1_OFOS_SO_CAM-1_20190304_083724.JPG"][1].image_datetime == datetime.datetime(2019, 3, 4, 8, 37, 25)
+    assert ifdo.image_set_items["SO268-1_21-1_OFOS_SO_CAM-1_20190304_083724.JPG"][
+        1
+    ].image_datetime == datetime.datetime(2019, 3, 4, 8, 37, 25)

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -8,11 +8,16 @@ from ifdo.models import ImageLicense, ImageContext, ImagePI, ImageCreator, Image
 
 OUTPUT_PATH = "/tmp/test_ifdo.json"
 
+
 def test_save():
-    ifdo = iFDO(image_set_header=ImageSetHeader(image_set_name="SO268 SO268-1_21-1_OFOS SO_CAM-1_Photo_OFOS",
-                                                image_set_uuid="f840644a-fe4a-46a7-9791-e32c211bcbf5",
-                                                image_set_handle= "https://hdl.handle.net/20.500.12085/f840644a-fe4a-46a7-9791-e32c211bcbf5"),
-                image_set_items={})
+    ifdo = iFDO(
+        image_set_header=ImageSetHeader(
+            image_set_name="SO268 SO268-1_21-1_OFOS SO_CAM-1_Photo_OFOS",
+            image_set_uuid="f840644a-fe4a-46a7-9791-e32c211bcbf5",
+            image_set_handle="https://hdl.handle.net/20.500.12085/f840644a-fe4a-46a7-9791-e32c211bcbf5",
+        ),
+        image_set_items={},
+    )
 
     ifdo.image_set_header.image_abstract = "Acquired by camera SO_CAM-1_Photo_OFOS mounted on platform SO_PFM-01_OFOS during project SO268 (event: SO268-1_21-1_OFOS). Navigation data were automatically edited by the MarIQT software (removal of outliers, smoothed and splined to fill time gaps) and linked to the image data by timestamp."
     ifdo.image_set_header.image_copyright = "Copyright (C)"
@@ -55,6 +60,7 @@ def test_save():
     )
     validator = Draft202012Validator(schema, registry=registry)
     validator.validate(result)
+
 
 def load_json(filepath: str) -> dict:
     with open(filepath, "r") as file:


### PR DESCRIPTION
Added missing `image-set-local-path` field to `ImageData` and `ImageSetHeader`.

While the name suggests, that this field can only be used in the header, the standard allows the usage of all field in both `image-set-header` and `image-set-items`.

Please see both issues for reference:
- https://codebase.helmholtz.cloud/datahub/marehub/ag-videosimages/fair-marine-images/-/issues/71
- https://github.com/csiro-fair/marimba/issues/13