### PR TITLE
[Feature] Image-datetime format-aware serialization and deserialization

### DIFF
--- a/config/mypy.ini
+++ b/config/mypy.ini
@@ -17,3 +17,5 @@ warn_unused_configs = True
 # Import settings
 ignore_missing_imports = True
 follow_imports = silent
+
+plugins = pydantic.mypy

--- a/ifdo/_datetime/__init__.py
+++ b/ifdo/_datetime/__init__.py
@@ -1,4 +1,4 @@
 from ._check_datetime import check_datatime_format
 from ._serialize_datetime import add_datetime_format_info
 
-__all__ = ["check_datatime_format", "add_datetime_format_info"]
+__all__ = ["add_datetime_format_info", "check_datatime_format"]

--- a/ifdo/_datetime/__init__.py
+++ b/ifdo/_datetime/__init__.py
@@ -1,0 +1,4 @@
+from ._check_datetime import check_datatime_format
+from ._serialize_datetime import add_datetime_format_info
+
+__all__ = ["check_datatime_format", "add_datetime_format_info"]

--- a/ifdo/_datetime/__init__.py
+++ b/ifdo/_datetime/__init__.py
@@ -1,4 +1,4 @@
-from ._check_datetime import check_datatime_format
+from ._check_datetime import check_datetime_format
 from ._serialize_datetime import add_datetime_format_info
 
-__all__ = ["add_datetime_format_info", "check_datatime_format"]
+__all__ = ["add_datetime_format_info", "check_datetime_format"]

--- a/ifdo/_datetime/_check_datetime.py
+++ b/ifdo/_datetime/_check_datetime.py
@@ -37,9 +37,12 @@ def _check_image_item(item: dict[str, Any], header_format: str) -> str:
     datetime_format: str = item.get("image-datetime-format", header_format)
 
     if "image-datetime" in item:
-        item["image-datetime"] = datetime.strptime(
-            item["image-datetime"],
-            datetime_format,
-        ).replace(tzinfo=timezone.utc)
+        try:
+            item["image-datetime"] = datetime.strptime(
+                item["image-datetime"],
+                datetime_format,
+            ).replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            pass  # Leave as string; Pydantic handles ISO 8601 natively
 
     return datetime_format

--- a/ifdo/_datetime/_check_datetime.py
+++ b/ifdo/_datetime/_check_datetime.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import Any
+
+from ._format import DEFAULT_DATETIME_FORMAT
+
+
+def check_datatime_format(ifdo_data: dict[str, Any]) -> None:
+    if "image-set-header" not in ifdo_data:
+        return
+    image_set_header = ifdo_data["image-set-header"]
+
+    header_datetime_format = _check_image_item(
+        image_set_header, DEFAULT_DATETIME_FORMAT
+    )
+
+    if "image-set-items" not in ifdo_data:
+        return
+
+    for item in ifdo_data["image-set-items"].values():
+        if isinstance(item, dict):
+            _check_image_item(item, header_datetime_format)
+        else:
+            _check_video_item(item, header_datetime_format)
+
+
+def _check_video_item(items: list[dict[str, Any]], header_format) -> None:
+    if len(items) == 0:
+        return
+
+    prefix_format = _check_image_item(items[0], header_format)
+    for item in items[1:]:
+        _check_image_item(item, prefix_format)
+
+
+def _check_image_item(item: dict[str, Any], header_format: str) -> str:
+    datetime_format = item.get("image-datetime-format", header_format)
+
+    if "image-datetime" in item:
+        item["image-datetime"] = datetime.strptime(
+            item["image-datetime"], datetime_format
+        )
+
+    return datetime_format

--- a/ifdo/_datetime/_check_datetime.py
+++ b/ifdo/_datetime/_check_datetime.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from ._format import DEFAULT_DATETIME_FORMAT
@@ -10,7 +10,8 @@ def check_datatime_format(ifdo_data: dict[str, Any]) -> None:
     image_set_header = ifdo_data["image-set-header"]
 
     header_datetime_format = _check_image_item(
-        image_set_header, DEFAULT_DATETIME_FORMAT
+        image_set_header,
+        DEFAULT_DATETIME_FORMAT,
     )
 
     if "image-set-items" not in ifdo_data:
@@ -23,7 +24,7 @@ def check_datatime_format(ifdo_data: dict[str, Any]) -> None:
             _check_video_item(item, header_datetime_format)
 
 
-def _check_video_item(items: list[dict[str, Any]], header_format) -> None:
+def _check_video_item(items: list[dict[str, Any]], header_format: str) -> None:
     if len(items) == 0:
         return
 
@@ -33,11 +34,12 @@ def _check_video_item(items: list[dict[str, Any]], header_format) -> None:
 
 
 def _check_image_item(item: dict[str, Any], header_format: str) -> str:
-    datetime_format = item.get("image-datetime-format", header_format)
+    datetime_format: str = item.get("image-datetime-format", header_format)
 
     if "image-datetime" in item:
         item["image-datetime"] = datetime.strptime(
-            item["image-datetime"], datetime_format
-        )
+            item["image-datetime"],
+            datetime_format,
+        ).replace(tzinfo=timezone.utc)
 
     return datetime_format

--- a/ifdo/_datetime/_check_datetime.py
+++ b/ifdo/_datetime/_check_datetime.py
@@ -4,7 +4,7 @@ from typing import Any
 from ._format import DEFAULT_DATETIME_FORMAT
 
 
-def check_datatime_format(ifdo_data: dict[str, Any]) -> None:
+def check_datetime_format(ifdo_data: dict[str, Any]) -> None:
     if "image-set-header" not in ifdo_data:
         return
     image_set_header = ifdo_data["image-set-header"]

--- a/ifdo/_datetime/_format.py
+++ b/ifdo/_datetime/_format.py
@@ -1,0 +1,1 @@
+DEFAULT_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"

--- a/ifdo/_datetime/_serialize_datetime.py
+++ b/ifdo/_datetime/_serialize_datetime.py
@@ -1,0 +1,37 @@
+from typing import TYPE_CHECKING
+
+from ifdo._datetime._format import DEFAULT_DATETIME_FORMAT
+
+if TYPE_CHECKING:
+    from ifdo import iFDO, ImageData
+
+
+def add_datetime_format_info(ifdo: "iFDO") -> None:
+    header_format = (
+        ifdo.image_set_header.image_datetime_format or DEFAULT_DATETIME_FORMAT
+    )
+
+    setattr(ifdo.image_set_header, "_image_datetime_format", header_format)
+
+    for image_item in ifdo.image_set_items.values():
+        if isinstance(image_item, list):
+            _serialize_video_datetimes(image_item, header_format)
+        else:
+            _serialize_image_datetimes(image_item, header_format)
+
+
+def _serialize_video_datetimes(images: list["ImageData"], header_format: str) -> None:
+    if len(images) == 0:
+        return
+
+    datetime_format = _serialize_image_datetimes(images[0], header_format)
+
+    for image in images[1:]:
+        _serialize_image_datetimes(image, datetime_format)
+
+
+def _serialize_image_datetimes(image: "ImageData", header_format: str) -> str:
+    datetime_format = image.image_datetime_format or header_format
+
+    setattr(image, "_image_datetime_format", datetime_format)
+    return datetime_format

--- a/ifdo/_datetime/_serialize_datetime.py
+++ b/ifdo/_datetime/_serialize_datetime.py
@@ -3,15 +3,13 @@ from typing import TYPE_CHECKING
 from ifdo._datetime._format import DEFAULT_DATETIME_FORMAT
 
 if TYPE_CHECKING:
-    from ifdo import iFDO, ImageData
+    from ifdo import ImageData, iFDO
 
 
 def add_datetime_format_info(ifdo: "iFDO") -> None:
-    header_format = (
-        ifdo.image_set_header.image_datetime_format or DEFAULT_DATETIME_FORMAT
-    )
+    header_format = ifdo.image_set_header.image_datetime_format or DEFAULT_DATETIME_FORMAT
 
-    setattr(ifdo.image_set_header, "_image_datetime_format", header_format)
+    ifdo.image_set_header._image_datetime_format = header_format  # type: ignore[attr-defined] # noqa: SLF001
 
     for image_item in ifdo.image_set_items.values():
         if isinstance(image_item, list):
@@ -33,5 +31,5 @@ def _serialize_video_datetimes(images: list["ImageData"], header_format: str) ->
 def _serialize_image_datetimes(image: "ImageData", header_format: str) -> str:
     datetime_format = image.image_datetime_format or header_format
 
-    setattr(image, "_image_datetime_format", datetime_format)
+    image._image_datetime_format = datetime_format  # type: ignore[attr-defined] # noqa: SLF001
     return datetime_format

--- a/ifdo/models/ifdo.py
+++ b/ifdo/models/ifdo.py
@@ -22,21 +22,28 @@ Classes:
     iFDO: Implements the Image FAIR Digital Object specification.
 """
 
-from __future__ import annotations
-
 import json
+from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 import yaml
+from pydantic import SerializerFunctionWrapHandler, model_serializer, model_validator
 
+from ifdo._datetime import check_datatime_format
+from ifdo._datetime._serialize_datetime import add_datetime_format_info
 from ifdo.models._kebab_case_model import KebabCaseModel
 from ifdo.models.ifdo_capture import ImageCaptureFields
 from ifdo.models.ifdo_content import ImageContentFields
 from ifdo.models.ifdo_core import ImageCoreFields
 
 
-class ImageData(KebabCaseModel, ImageCoreFields, ImageCaptureFields, ImageContentFields):
+class ImageData(
+    KebabCaseModel,
+    ImageCoreFields,
+    ImageCaptureFields,
+    ImageContentFields,
+):
     """
     Represent image data with associated metadata and annotations.
 
@@ -120,7 +127,12 @@ class ImageData(KebabCaseModel, ImageCoreFields, ImageCaptureFields, ImageConten
     image_handle: str | None = None
 
 
-class ImageSetHeader(KebabCaseModel, ImageCoreFields, ImageCaptureFields, ImageContentFields):
+class ImageSetHeader(
+    KebabCaseModel,
+    ImageCoreFields,
+    ImageCaptureFields,
+    ImageContentFields,
+):
     """
     Represent an image set header with detailed metadata and attributes.
 
@@ -240,8 +252,22 @@ class iFDO(KebabCaseModel):  # noqa: N801
     image_set_header: ImageSetHeader
     image_set_items: dict[str, ImageData | list[ImageData]]
 
+    @model_serializer(mode="wrap")
+    def serialize(self, nxt: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        ifdo = deepcopy(self)
+        add_datetime_format_info(ifdo)
+        return nxt(ifdo)
+
+    @model_validator(mode="before")
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> iFDO:
+    def validate_image_datatime(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        check_datatime_format(data)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
         """Create an iFDO instance from a dictionary."""
         return cls.model_validate(data)
 
@@ -250,7 +276,7 @@ class iFDO(KebabCaseModel):  # noqa: N801
         return self.model_dump(mode="json", by_alias=True, exclude_none=True)
 
     @classmethod
-    def load(cls, path: str | Path) -> iFDO:
+    def load(cls, path: str | Path) -> Self:
         """
         Load an iFDO from a YAML or JSON file.
 
@@ -271,7 +297,9 @@ class iFDO(KebabCaseModel):  # noqa: N801
             elif suffix == "json":
                 d = json.load(f)
             else:
-                raise ValueError("Unsupported file format. Use YAML (.yaml, .yml) or JSON (.json).")
+                raise ValueError(
+                    "Unsupported file format. Use YAML (.yaml, .yml) or JSON (.json).",
+                )
 
         return cls.from_dict(d)
 

--- a/ifdo/models/ifdo.py
+++ b/ifdo/models/ifdo.py
@@ -32,7 +32,7 @@ from typing import Any, cast
 import yaml
 from pydantic import SerializerFunctionWrapHandler, model_serializer, model_validator
 
-from ifdo._datetime import check_datatime_format
+from ifdo._datetime import check_datetime_format
 from ifdo._datetime._serialize_datetime import add_datetime_format_info
 from ifdo.models._kebab_case_model import KebabCaseModel
 from ifdo.models.ifdo_capture import ImageCaptureFields
@@ -262,10 +262,10 @@ class iFDO(KebabCaseModel):  # noqa: N801
 
     @model_validator(mode="before")
     @classmethod
-    def _validate_image_datatime(cls, data: Any) -> Any:  # noqa: ANN401
+    def _validate_image_datetime(cls, data: Any) -> Any:  # noqa: ANN401
         if not isinstance(data, dict):
             return data
-        check_datatime_format(data)
+        check_datetime_format(data)
         return data
 
     @classmethod

--- a/ifdo/models/ifdo.py
+++ b/ifdo/models/ifdo.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 from pydantic import SerializerFunctionWrapHandler, model_serializer, model_validator
@@ -255,14 +255,14 @@ class iFDO(KebabCaseModel):  # noqa: N801
     image_set_items: dict[str, ImageData | list[ImageData]]
 
     @model_serializer(mode="wrap")
-    def serialize(self, nxt: SerializerFunctionWrapHandler) -> dict[str, Any]:
+    def _serialize(self, nxt: SerializerFunctionWrapHandler) -> dict[str, Any]:
         ifdo = deepcopy(self)
         add_datetime_format_info(ifdo)
-        return nxt(ifdo)
+        return cast("dict[str, Any]", nxt(ifdo))
 
     @model_validator(mode="before")
     @classmethod
-    def validate_image_datatime(cls, data: Any) -> Any:
+    def _validate_image_datatime(cls, data: Any) -> Any:  # noqa: ANN401
         if not isinstance(data, dict):
             return data
         check_datatime_format(data)

--- a/ifdo/models/ifdo.py
+++ b/ifdo/models/ifdo.py
@@ -22,10 +22,12 @@ Classes:
     iFDO: Implements the Image FAIR Digital Object specification.
 """
 
+from __future__ import annotations
+
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Self
+from typing import Any
 
 import yaml
 from pydantic import SerializerFunctionWrapHandler, model_serializer, model_validator
@@ -267,7 +269,7 @@ class iFDO(KebabCaseModel):  # noqa: N801
         return data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Self:
+    def from_dict(cls, data: dict[str, Any]) -> iFDO:
         """Create an iFDO instance from a dictionary."""
         return cls.model_validate(data)
 
@@ -276,7 +278,7 @@ class iFDO(KebabCaseModel):  # noqa: N801
         return self.model_dump(mode="json", by_alias=True, exclude_none=True)
 
     @classmethod
-    def load(cls, path: str | Path) -> Self:
+    def load(cls, path: str | Path) -> iFDO:
         """
         Load an iFDO from a YAML or JSON file.
 

--- a/ifdo/models/ifdo_capture.py
+++ b/ifdo/models/ifdo_capture.py
@@ -402,7 +402,6 @@ class ImageCaptureFields:
     image_camera_pitch_degrees: float | None = None
     image_camera_roll_degrees: float | None = None
     image_overlap_fraction: float | None = None
-    image_datetime_format: str | None = None
     image_camera_pose: ImageCameraPose | None = None
     image_camera_housing_viewport: ImageCameraHousingViewport | None = None
     image_flatport_parameters: ImageFlatportParameters | None = None

--- a/ifdo/models/ifdo_core.py
+++ b/ifdo/models/ifdo_core.py
@@ -8,7 +8,7 @@ Classes:
     ImageLicense: Represents an image license.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field, field_serializer
 
@@ -110,7 +110,7 @@ class ImageCoreFields(BaseModel):
     image_set_local_path: str | None = None
 
     @field_serializer("image_datetime", when_used="json")
-    def serialize_image_datetime(self, image_datetime: datetime | None) -> str | None:
+    def _serialize_image_datetime(self, image_datetime: datetime | None) -> str | None:
         if image_datetime is None:
             return None
 
@@ -119,6 +119,9 @@ class ImageCoreFields(BaseModel):
             "_image_datetime_format",
             DEFAULT_DATETIME_FORMAT,
         )
+
+        if image_datetime.tzinfo is not None:
+            image_datetime = image_datetime.astimezone(timezone.utc)
 
         if datetime_format is not None and datetime_format != "":
             return image_datetime.strftime(datetime_format)

--- a/ifdo/models/ifdo_core.py
+++ b/ifdo/models/ifdo_core.py
@@ -10,7 +10,9 @@ Classes:
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
+
+from ifdo._datetime._format import DEFAULT_DATETIME_FORMAT
 
 
 class ImagePI(BaseModel):
@@ -85,10 +87,11 @@ class ImageLicense(BaseModel):
         return hash((self.name, self.uri))
 
 
-class ImageCoreFields:
+class ImageCoreFields(BaseModel):
     """Core metadata fields for iFDO objects."""
 
     image_datetime: datetime | None = None
+    image_datetime_format: str | None = None
     image_latitude: float | None = Field(None, ge=-90, le=90)
     image_longitude: float | None = Field(None, ge=-180, le=180)
     image_altitude_meters: float | None = None
@@ -105,3 +108,18 @@ class ImageCoreFields:
     image_copyright: str | None = None
     image_abstract: str | None = None
     image_set_local_path: str | None = None
+
+    @field_serializer("image_datetime", when_used="json")
+    def serialize_image_datetime(self, image_datetime: datetime | None) -> str | None:
+        if image_datetime is None:
+            return None
+
+        datetime_format = getattr(
+            self,
+            "_image_datetime_format",
+            DEFAULT_DATETIME_FORMAT,
+        )
+
+        if datetime_format is not None and datetime_format != "":
+            return image_datetime.strftime(datetime_format)
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ifdo"
-version = "1.3.0"
+version = "1.4.0"
 description = "Python iFDO implementation"
 readme = "README.md"
 authors = [

--- a/tests/test_check_datetime.py
+++ b/tests/test_check_datetime.py
@@ -1,0 +1,71 @@
+import pytest
+from ifdo._datetime import check_datatime_format
+
+
+def test_check_datatime_default() -> None:
+    valid_test_data = {
+        "image-set-header": {
+            "image-datetime": "2015-01-01 02:04:03.1000",
+        }
+    }
+
+    check_datatime_format(valid_test_data)
+
+    invalid_test_data = {
+        "image-set-header": {
+            "image-datetime": "2015-01-01 02:04:03",
+        }
+    }
+    with pytest.raises(Exception):
+        check_datatime_format(invalid_test_data)
+
+
+def test_check_datetime_images() -> None:
+    valid_test_data = {
+        "image-set-header": {
+            "image-datetime": "2015-01-01T20:21:32",
+            "image-datetime-format": "%Y-%m-%dT%H:%M:%S",
+        },
+        "image-set-items": {"image": {"image-datetime": "2015-01-01T20:21:32"}},
+    }
+    check_datatime_format(valid_test_data)
+    invalid_test_data = {
+        "image-set-header": {
+            "image-datetime": "2015-01-01T20:21:32",
+            "image-datetime-format": "%Y-%m-%dT%H:%M:%S",
+        },
+        "image-set-items": {"image": {"image-datetime": "2015-01-01 20:21:32"}},
+    }
+    with pytest.raises(Exception):
+        check_datatime_format(invalid_test_data)
+
+
+def test_check_datetime_videos() -> None:
+    valid_test_data = {
+        "image-set-header": {},
+        "image-set-items": {
+            "image": [
+                {
+                    "image-datetime-format": "%Y-%m-%dT%H:%M:%S",
+                    "image-datetime": "2015-01-01T20:21:32",
+                },
+                {"image-datetime": "2015-01-01T20:21:32"},
+            ]
+        },
+    }
+    check_datatime_format(valid_test_data)
+    invalid_test_data = {
+        "image-set-header": {},
+        "image-set-items": {
+            "image": [
+                {
+                    "image-datetime-format": "%Y-%m-%dT%H:%M:%S",
+                    "image-datetime": "2015-01-01T20:21:32",
+                },
+                {"image-datetime": "2015-01-01 20:21:32"},
+            ]
+        },
+    }
+
+    with pytest.raises(Exception):
+        check_datatime_format(invalid_test_data)

--- a/tests/test_check_datetime.py
+++ b/tests/test_check_datetime.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from ifdo._datetime import check_datatime_format
+from ifdo._datetime import check_datetime_format
 
 
 def test_check_datatime_default() -> None:
@@ -10,7 +10,7 @@ def test_check_datatime_default() -> None:
             "image-datetime": "2015-01-01 02:04:03.1000",
         }
     }
-    check_datatime_format(matching_data)
+    check_datetime_format(matching_data)
     assert matching_data["image-set-header"]["image-datetime"] == datetime(
         2015, 1, 1, 2, 4, 3, 100000, tzinfo=timezone.utc
     )
@@ -21,7 +21,7 @@ def test_check_datatime_default() -> None:
             "image-datetime": "2015-01-01 02:04:03",
         }
     }
-    check_datatime_format(fallback_data)
+    check_datetime_format(fallback_data)
     assert fallback_data["image-set-header"]["image-datetime"] == "2015-01-01 02:04:03"
 
 
@@ -34,7 +34,7 @@ def test_check_datetime_images() -> None:
         },
         "image-set-items": {"image": {"image-datetime": "2015-01-01T20:21:32"}},
     }
-    check_datatime_format(matching_data)
+    check_datetime_format(matching_data)
     assert matching_data["image-set-items"]["image"]["image-datetime"] == datetime(
         2015, 1, 1, 20, 21, 32, tzinfo=timezone.utc
     )
@@ -47,7 +47,7 @@ def test_check_datetime_images() -> None:
         },
         "image-set-items": {"image": {"image-datetime": "2015-01-01 20:21:32"}},
     }
-    check_datatime_format(fallback_data)
+    check_datetime_format(fallback_data)
     assert fallback_data["image-set-items"]["image"]["image-datetime"] == "2015-01-01 20:21:32"
 
 
@@ -65,7 +65,7 @@ def test_check_datetime_videos() -> None:
             ]
         },
     }
-    check_datatime_format(matching_data)
+    check_datetime_format(matching_data)
     assert matching_data["image-set-items"]["image"][1]["image-datetime"] == datetime(
         2015, 1, 1, 20, 21, 32, tzinfo=timezone.utc
     )
@@ -83,5 +83,5 @@ def test_check_datetime_videos() -> None:
             ]
         },
     }
-    check_datatime_format(fallback_data)
+    check_datetime_format(fallback_data)
     assert fallback_data["image-set-items"]["image"][1]["image-datetime"] == "2015-01-01 20:21:32"

--- a/tests/test_check_datetime.py
+++ b/tests/test_check_datetime.py
@@ -1,47 +1,59 @@
-import pytest
+from datetime import datetime, timezone
+
 from ifdo._datetime import check_datatime_format
 
 
 def test_check_datatime_default() -> None:
-    valid_test_data = {
+    # Matching the default format: string is converted to datetime
+    matching_data = {
         "image-set-header": {
             "image-datetime": "2015-01-01 02:04:03.1000",
         }
     }
+    check_datatime_format(matching_data)
+    assert matching_data["image-set-header"]["image-datetime"] == datetime(
+        2015, 1, 1, 2, 4, 3, 100000, tzinfo=timezone.utc
+    )
 
-    check_datatime_format(valid_test_data)
-
-    invalid_test_data = {
+    # Non-matching string (no microseconds): left as-is for Pydantic to handle
+    fallback_data = {
         "image-set-header": {
             "image-datetime": "2015-01-01 02:04:03",
         }
     }
-    with pytest.raises(Exception):
-        check_datatime_format(invalid_test_data)
+    check_datatime_format(fallback_data)
+    assert fallback_data["image-set-header"]["image-datetime"] == "2015-01-01 02:04:03"
 
 
 def test_check_datetime_images() -> None:
-    valid_test_data = {
+    # Matching format: string is converted to datetime
+    matching_data = {
         "image-set-header": {
             "image-datetime": "2015-01-01T20:21:32",
             "image-datetime-format": "%Y-%m-%dT%H:%M:%S",
         },
         "image-set-items": {"image": {"image-datetime": "2015-01-01T20:21:32"}},
     }
-    check_datatime_format(valid_test_data)
-    invalid_test_data = {
+    check_datatime_format(matching_data)
+    assert matching_data["image-set-items"]["image"]["image-datetime"] == datetime(
+        2015, 1, 1, 20, 21, 32, tzinfo=timezone.utc
+    )
+
+    # Non-matching string: left as-is for Pydantic to handle (backwards-compat fallback)
+    fallback_data = {
         "image-set-header": {
             "image-datetime": "2015-01-01T20:21:32",
             "image-datetime-format": "%Y-%m-%dT%H:%M:%S",
         },
         "image-set-items": {"image": {"image-datetime": "2015-01-01 20:21:32"}},
     }
-    with pytest.raises(Exception):
-        check_datatime_format(invalid_test_data)
+    check_datatime_format(fallback_data)
+    assert fallback_data["image-set-items"]["image"]["image-datetime"] == "2015-01-01 20:21:32"
 
 
 def test_check_datetime_videos() -> None:
-    valid_test_data = {
+    # Matching format: first frame's format inherited by subsequent frames
+    matching_data = {
         "image-set-header": {},
         "image-set-items": {
             "image": [
@@ -53,8 +65,13 @@ def test_check_datetime_videos() -> None:
             ]
         },
     }
-    check_datatime_format(valid_test_data)
-    invalid_test_data = {
+    check_datatime_format(matching_data)
+    assert matching_data["image-set-items"]["image"][1]["image-datetime"] == datetime(
+        2015, 1, 1, 20, 21, 32, tzinfo=timezone.utc
+    )
+
+    # Non-matching string on subsequent frame: left as-is for Pydantic to handle
+    fallback_data = {
         "image-set-header": {},
         "image-set-items": {
             "image": [
@@ -66,6 +83,5 @@ def test_check_datetime_videos() -> None:
             ]
         },
     }
-
-    with pytest.raises(Exception):
-        check_datatime_format(invalid_test_data)
+    check_datatime_format(fallback_data)
+    assert fallback_data["image-set-items"]["image"][1]["image-datetime"] == "2015-01-01 20:21:32"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,5 +1,5 @@
 import datetime
-
+from datetime import timezone
 import json
 
 from ifdo import iFDO, ImageData
@@ -12,10 +12,13 @@ def test_load_image_example():
     ifdo = iFDO.from_dict(json_data)
 
     assert ifdo.image_set_header.image_set_name == "SO268 SO268-1_21-1_OFOS SO_CAM-1_Photo_OFOS"
-    assert isinstance(ifdo.image_set_items["SO268-1_21-1_OFOS_SO_CAM-1_20190304_083724.JPG"], ImageData)
+    assert isinstance(
+        ifdo.image_set_items["SO268-1_21-1_OFOS_SO_CAM-1_20190304_083724.JPG"],
+        ImageData,
+    )
     assert ifdo.image_set_items["SO268-1_21-1_OFOS_SO_CAM-1_20190304_083724.JPG"].image_datetime == datetime.datetime(
         2019, 3, 4, 8, 37, 24
-    )
+    ).replace(tzinfo=timezone.utc)
 
 
 def test_load_video_example():
@@ -27,6 +30,6 @@ def test_load_video_example():
     assert ifdo.image_set_header.image_set_name == "SO268 SO268-1_21-1_OFOS SO_CAM-1_Photo_OFOS"
     image_data = ifdo.image_set_items["SO268-1_21-1_OFOS_SO_CAM-1_20190304_083724.JPG"]
     if isinstance(image_data, list):
-        assert image_data[1].image_datetime == datetime.datetime(2019, 3, 4, 8, 37, 25)
+        assert image_data[1].image_datetime == datetime.datetime(2019, 3, 4, 8, 37, 25).replace(tzinfo=timezone.utc)
     else:
-        assert image_data.image_datetime == datetime.datetime(2019, 3, 4, 8, 37, 25)
+        assert image_data.image_datetime == datetime.datetime(2019, 3, 4, 8, 37, 25).replace(tzinfo=timezone.utc)

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -40,7 +40,6 @@ def create_ifdo() -> iFDO:
             image_set_name="SO268 SO268-1_21-1_OFOS SO_CAM-1_Photo_OFOS",
             image_set_uuid="f840644a-fe4a-46a7-9791-e32c211bcbf5",
             image_set_handle="https://hdl.handle.net/20.500.12085/f840644a-fe4a-46a7-9791-e32c211bcbf5",
-            image_datetime=datetime(2025, 1, 1, 1, 1, 1, 100000),
         ),
         image_set_items={},
     )
@@ -60,12 +59,16 @@ def create_ifdo() -> iFDO:
     ifdo.image_set_header.image_altitude_meters = 1.0
     ifdo.image_set_header.image_coordinate_reference_system = "WSG84"
     ifdo.image_set_header.image_coordinate_uncertainty_meters = 0.1
+    ifdo.image_set_header.image_datetime = datetime(2025, 1, 1, 1, 1, 1, 100000)
 
     return ifdo
 
 
 def create_ifdo_item() -> ImageData:
-    image = ImageData()
+    image = ImageData(
+        image_latitude=0.0,
+        image_longitude=0.0,
+    )
     image.image_handle = "test"
     image.image_hash_sha256 = "83f30eb35d1325c44c85fba0cf478825c0a629d20177a945069934f6cd07e087"
     image.image_uuid = "c6b8d981-05c7-449f-85a9-906ab866bfb6"

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -5,7 +5,14 @@ from typing import Any, cast
 from jsonschema import Draft202012Validator
 from referencing import Registry, Resource
 from ifdo import iFDO
-from ifdo.models import ImageLicense, ImageContext, ImagePI, ImageCreator, ImageData, ImageSetHeader
+from ifdo.models import (
+    ImageLicense,
+    ImageContext,
+    ImagePI,
+    ImageCreator,
+    ImageData,
+    ImageSetHeader,
+)
 
 OUTPUT_PATH = "/tmp/test_ifdo.json"
 
@@ -13,8 +20,11 @@ OUTPUT_PATH = "/tmp/test_ifdo.json"
 def test_save_image():
     ifdo = create_ifdo()
     ifdo.image_set_items["SO268-1_21-1_OFOS_SO_CAM-1_20190304_083724.JPG"] = create_ifdo_item()
-
     validate_ifdo(ifdo)
+
+    result = ifdo.to_dict()
+    assert "_image_datetime_format" not in result["image-set-header"]
+    assert result["image-set-header"]["image-datetime"] == "2025-01-01 01:01:01.100000"
 
 
 def test_save_video():
@@ -30,6 +40,7 @@ def create_ifdo() -> iFDO:
             image_set_name="SO268 SO268-1_21-1_OFOS SO_CAM-1_Photo_OFOS",
             image_set_uuid="f840644a-fe4a-46a7-9791-e32c211bcbf5",
             image_set_handle="https://hdl.handle.net/20.500.12085/f840644a-fe4a-46a7-9791-e32c211bcbf5",
+            image_datetime=datetime(2025, 1, 1, 1, 1, 1, 100000),
         ),
         image_set_items={},
     )
@@ -49,7 +60,6 @@ def create_ifdo() -> iFDO:
     ifdo.image_set_header.image_altitude_meters = 1.0
     ifdo.image_set_header.image_coordinate_reference_system = "WSG84"
     ifdo.image_set_header.image_coordinate_uncertainty_meters = 0.1
-    ifdo.image_set_header.image_datetime = datetime(2020, 1, 1)
 
     return ifdo
 

--- a/tests/test_serialize_datetime.py
+++ b/tests/test_serialize_datetime.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from ifdo._datetime import add_datetime_format_info
-from ifdo.models.ifdo import ImageData, ImageSetHeader, iFDO
+from ifdo.models.ifdo import ImageSetHeader, iFDO
 
 
 def test_serialize_datetimes() -> None:
@@ -8,8 +8,10 @@ def test_serialize_datetimes() -> None:
         image_set_name="",
         image_set_uuid="",
         image_set_handle="",
-        image_datetime=datetime(2025, 1, 1, 1, 1, 1, int(2 * 1e5)),
+        image_latitude=0,
+        image_longitude=0,
     )
+    header.image_datetime = datetime(2025, 1, 1, 1, 1, 1, int(2 * 1e5))
 
     ifdo = iFDO(image_set_header=header, image_set_items={})
 

--- a/tests/test_serialize_datetime.py
+++ b/tests/test_serialize_datetime.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from ifdo._datetime import add_datetime_format_info
+from ifdo.models.ifdo import ImageData, ImageSetHeader, iFDO
+
+
+def test_serialize_datetimes() -> None:
+    header = ImageSetHeader(
+        image_set_name="",
+        image_set_uuid="",
+        image_set_handle="",
+        image_datetime=datetime(2025, 1, 1, 1, 1, 1, int(2 * 1e5)),
+    )
+
+    ifdo = iFDO(image_set_header=header, image_set_items={})
+
+    add_datetime_format_info(ifdo)
+
+    result = ifdo.model_dump(mode="json", by_alias=True, exclude_none=True)
+    print(ifdo.image_set_header.__annotations__)
+    assert result["image-set-header"]["image-datetime"] == "2025-01-01 01:01:01.200000"


### PR DESCRIPTION
## Summary

This PR merges the `dev` branch into `main` to release v1.4.0. It makes `image-datetime` serialization and deserialization aware of the `image-datetime-format` field, so that datetime strings are written using the format declared in the iFDO file rather than Pydantic's default ISO 8601 output. The default format is `%Y-%m-%d %H:%M:%S.%f` with a space separator, as specified by the iFDO v2.1.0 schema. Loaded datetimes are parsed using the declared format and stored as UTC-aware objects. The format is inherited from the image-set-header to image-set-items, and from the first frame to subsequent frames for video items. A backwards-compatibility fallback ensures existing files with mismatched datetime strings continue to load without error.

## Problem

The `image-datetime` field was being serialized by Pydantic's default datetime handler, producing ISO 8601 strings with a `T` separator (e.g. `2019-03-04T08:37:24Z`) regardless of the declared `image-datetime-format`. This violated the iFDO v2.1.0 spec, which defines the default format as `%Y-%m-%d %H:%M:%S.%f`. Additionally, the `image-datetime-format` field was not used during deserialization, meaning datetime strings were not validated or parsed according to their declared format.

## Solution

A new `ifdo/_datetime/` module handles format-aware parsing and serialization. A `model_validator` pre-processes raw dict data on load, converting datetime strings to UTC-aware datetime objects using the declared format with a lenient fallback for mismatched strings. A `model_serializer` on `iFDO` propagates the correct format to each `ImageData` instance before serialization, and a `field_serializer` on `image_datetime` writes the string using that format. The `image_datetime_format` field has been moved from `ImageCaptureFields` to `ImageCoreFields` to reflect its role in both capture and core metadata.

## Design

The format inheritance logic mirrors the iFDO spec: the image-set-header format is the default for all items, overridden per-item by a locally declared `image-datetime-format`, with video frames inheriting from the first frame. The serializer uses a private `_image_datetime_format` attribute set on a deepcopy of the `iFDO` object to avoid mutating state during serialization. The backwards-compatibility fallback in `_check_image_item` silently passes on `ValueError`, leaving non-matching strings for Pydantic's own ISO 8601 handling.

## Impact

Datetime strings in newly written iFDO files will now use the spec-defined space-separated format, improving compliance. Existing files that contain ISO 8601 datetime strings load cleanly via the fallback. Consumers that parse `image-datetime` strings directly rather than using the Python library may see a format change in output files.

## Testing

Tests for the new `_datetime` module cover format-matching (asserting parsed datetime objects), format fallback (asserting strings are left unchanged), format inheritance for images and videos, and round-trip load/save behaviour. All 8 tests pass.

## Breaking Changes

The serialized format of `image-datetime` changes from ISO 8601 (e.g. `2019-03-04T08:37:24Z`) to the spec-defined default (e.g. `2019-03-04 08:37:24.000000`) for files that do not declare a custom `image-datetime-format`. Consumers that parse datetime strings directly from iFDO files should update accordingly.

## Added Files

- `ifdo/_datetime/__init__.py`: Public exports for the datetime module
- `ifdo/_datetime/_check_datetime.py`: Format-aware datetime parsing with backwards-compatible fallback
- `ifdo/_datetime/_format.py`: Default datetime format constant
- `ifdo/_datetime/_serialize_datetime.py`: Format propagation logic for serialization
- `tests/test_check_datetime.py`: Tests for datetime parsing and fallback behaviour
- `tests/test_serialize_datetime.py`: Tests for datetime serialization

## Modified Files

- `ifdo/models/ifdo.py`: Added `model_validator` and `model_serializer` for format-aware datetime handling
- `ifdo/models/ifdo_core.py`: Moved `image_datetime_format` here from `ImageCaptureFields`; added `field_serializer` for `image_datetime`
- `ifdo/models/ifdo_capture.py`: Removed `image_datetime_format` (moved to `ImageCoreFields`)
- `pyproject.toml`: Bumped version to 1.4.0
- `config/mypy.ini`: Added pydantic mypy plugin
- `tests/test_load.py`: Updated datetime assertions to expect UTC-aware objects
- `tests/test_save.py`: Updated for new serialization format